### PR TITLE
chore(workflow): Update repository url

### DIFF
--- a/.github/workflows/sync-ec-cli-tasks.yaml
+++ b/.github/workflows/sync-ec-cli-tasks.yaml
@@ -27,7 +27,7 @@ jobs:
     - name: Checkout tekton-catalog
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
-        repository: enterprise-contract/tekton-catalog
+        repository: conforma/tekton-catalog
         ref: main
         path: tekton-catalog
 


### PR DESCRIPTION
This commit updates the repository url for the tekton-catalog repository which is used in the `.github/workflows/sync-ec-cli-tasks.yaml` file.

REF: EC-1108