### PR TITLE
chore: update reference to policy repo

### DIFF
--- a/tasks/verify-definition/0.1/README.md
+++ b/tasks/verify-definition/0.1/README.md
@@ -34,7 +34,7 @@ spec:
   - name: NAMESPACE
     value: policy.task.kind
   - name: POLICY_SOURCE
-    value: git::github.com/enterprise-contract/ec-policies//policy/task
+    value: git::github.com/conforma/policy//policy/task
   resources: {}
   serviceAccountName: default
   taskRef:

--- a/tasks/verify-definition/0.1/tests/verify-definition-taskrun.yaml
+++ b/tasks/verify-definition/0.1/tests/verify-definition-taskrun.yaml
@@ -27,7 +27,7 @@ spec:
   - name: NAMESPACE
     value: policy.task.kind
   - name: POLICY_SOURCE
-    value: git::github.com/enterprise-contract/ec-policies//policy/task
+    value: git::github.com/conforma/policy//policy/task
   resources: {}
   serviceAccountName: default
   taskRef:

--- a/tasks/verify-definition/0.1/verify-definition.yaml
+++ b/tasks/verify-definition/0.1/verify-definition.yaml
@@ -43,11 +43,11 @@ spec:
     - name: POLICY_LIB
       type: string
       description: The source containing the policy files libraries.
-      default: git::https://github.com/enterprise-contract/ec-policies//policy/lib
+      default: git::https://github.com/conforma/policy//policy/lib
     - name: POLICY_DATA
       type: string
       description: The source containing the policy files.
-      default: git::https://github.com/enterprise-contract/ec-policies//example/data
+      default: git::https://github.com/conforma/policy//example/data
     - name: HOMEDIR
       type: string
       description: Value for the HOME environment variable.

--- a/tasks/verify-enterprise-contract/0.1/tests/ecp-policy.yaml
+++ b/tasks/verify-enterprise-contract/0.1/tests/ecp-policy.yaml
@@ -23,7 +23,7 @@ spec:
   description: My custom enterprise contract policy configuration
   sources:
   - data:
-    - git::https://github.com/enterprise-contract/ec-policies//example/data
+    - git::https://github.com/conforma/policy//example/data
     name: ec-policy
     policy:
     - quay.io/enterprise-contract/ec-release-policy:latest


### PR DESCRIPTION
This commit updates references to the policy repo from `enterprise-contract/ec-policies` to `conforma/policy`.

Ref: EC-1113