### PR TITLE
Delete .github/dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: github-actions
-    directory: /
-    schedule:
-      interval: weekly
-      time: '15:00'
-      timezone: Etc/UTC


### PR DESCRIPTION
Deleting dependabot configs since we're migrating all the repos to renovate

Ref: https://issues.redhat.com/browse/EC-1455